### PR TITLE
fixed reference to box that is no longer available

### DIFF
--- a/sitespeed-centos7/Vagrantfile
+++ b/sitespeed-centos7/Vagrantfile
@@ -6,7 +6,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "chef/centos-7.0"
+  config.vm.box = "centos/7"
   config.vm.provider "virtualbox" do |vb|
     # vb.gui = true
 


### PR DESCRIPTION
fixes https://github.com/sitespeedio/sitespeed.io-vagrant/issues/1 

chef boxes are no longer available.
switched to centos supplied boxes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sitespeedio/sitespeed.io-vagrant/2)
<!-- Reviewable:end -->
