### PR TITLE
Yes, it is possible to run Chrome & the Chromedriver on CentOS.

### DIFF
--- a/sitespeed-centos7/setup.sh
+++ b/sitespeed-centos7/setup.sh
@@ -7,7 +7,7 @@ if [ ! -f /etc/root_provisioned_at ]
   yum update -y
 
   # You need the epel-release for NodeJS & npm
-  yum install -y git firefox java-1.7.0-openjdk epel-release
+  yum install -y git firefox java epel-release
 
   # Install what's needed for Xvfb
   yum -y install Xvfb libXfont Xorg
@@ -18,6 +18,23 @@ if [ ! -f /etc/root_provisioned_at ]
 
   # Install sitesped.io
   npm install -g sitespeed.io
+
+  # Install google-chrome and chromedriver
+  cat > /etc/yum.repos.d/google-chrome.repo << EOF
+[google-chrome]
+name=google-chrome
+baseurl=http://dl.google.com/linux/chrome/rpm/stable/x86_64/
+gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub
+enabled=1
+gpgcheck=1
+EOF
+  
+  yum install -y google-chrome-stable
+  mkdir -p /usr/lib/node_modules/sitespeed.io/node_modules/alto-saxophone/vendor/
+  cd       /usr/lib/node_modules/sitespeed.io/node_modules/alto-saxophone/vendor/
+  curl -s http://chromedriver.storage.googleapis.com/2.23/chromedriver_linux64.zip -o chromedriver.zip
+  unzip chromedriver.zip
+  
 
   date > /etc/root_provisioned_at
 fi


### PR DESCRIPTION
- 1.7 is to old.  openjdk version "1.8.0" works well.
- install libXfont, Xorg, groupinstall "X Window System" "Desktop" "Fonts" "General Purpose Desktop" - I doubt that it is really necessary.

Run using chrome (as a non root user !!! ):
```
Xvfb :10 -ac &
export DISPLAY=:10
sitespeed.io --debug http://ipchicken.com/
```

As result:
```
[2016-10-11 18:55:40] Versions OS: linux 3.10.0-327.36.1.el7.x86_64 nodejs: v6.7.0 sitespeed.io: 4.0.0-beta.4 browsertime: 1.0.0-beta.5 coach: 0.27.1
[2016-10-11 18:55:41] {
  "uuid": "e5c46da1-c05e-45bd-a17f-7070636fba9c",
  "type": "url",
  "timestamp": "2016-10-11T18:55:41-04:00",
  "source": "url-reader",
  "data": "{...}",
  "url": "http://ipchicken.com/",
  "group": "ipchicken.com"
} 
[2016-10-11 18:55:41] Starting chrome for analysing http://ipchicken.com/ 3 time(s)
[2016-10-11 18:55:41] Testing url http://ipchicken.com/ run 1
....
[2016-10-11 18:55:56] Render HTML for 1 page(s)
[2016-10-11 18:55:58] HTML stored in /home/default/sitespeed-result/ipchicken.com/2016-10-11-18-55-40
[2016-10-11 18:55:58] Finished analysing http://ipchicken.com/
```